### PR TITLE
use factories for auth and billing

### DIFF
--- a/bundle/src/Command/Sudo/SudoListCommand.php
+++ b/bundle/src/Command/Sudo/SudoListCommand.php
@@ -4,6 +4,7 @@ namespace Hyvor\Internal\Bundle\Command\Sudo;
 
 use Hyvor\Internal\Auth\AuthInterface;
 use Hyvor\Internal\Auth\Oidc\OidcAuth;
+use Hyvor\Internal\Billing\BillingInterface;
 use Hyvor\Internal\Sudo\SudoUserRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;

--- a/bundle/src/InternalBundle.php
+++ b/bundle/src/InternalBundle.php
@@ -2,16 +2,11 @@
 
 namespace Hyvor\Internal\Bundle;
 
-use Hyvor\Internal\Auth\Auth;
-use Hyvor\Internal\Auth\AuthFake;
+use Hyvor\Internal\Auth\AuthFactory;
 use Hyvor\Internal\Auth\AuthInterface;
-use Hyvor\Internal\Auth\Oidc\OidcAuth;
-use Hyvor\Internal\Billing\Billing;
-use Hyvor\Internal\Billing\BillingFake;
+use Hyvor\Internal\Billing\BillingFactory;
 use Hyvor\Internal\Billing\BillingInterface;
-use Hyvor\Internal\Component\Component;
 use Hyvor\Internal\InternalConfig;
-use Hyvor\Internal\InternalFake;
 use Hyvor\Internal\SelfHosted\SelfHostedTelemetry;
 use Hyvor\Internal\SelfHosted\SelfHostedTelemetryInterface;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -38,10 +33,6 @@ class InternalBundle extends AbstractBundle
         $definition->rootNode() // @phpstan-ignore-line
             ->children()
                 ->scalarNode('component')->defaultValue('core')->end()
-                ->scalarNode('auth_method')->defaultValue('%env(AUTH_METHOD)%')->end()
-                ->scalarNode('instance')->defaultValue('%env(HYVOR_INSTANCE)%')->end()
-                ->scalarNode('private_instance')->defaultValue('%env(HYVOR_PRIVATE_INSTANCE)%')->end()
-                ->booleanNode('fake')->defaultValue('%env(HYVOR_FAKE)%')->end()
                 ->arrayNode('i18n')
                     ->addDefaultsIfNotSet()
                     ->children()
@@ -61,12 +52,11 @@ class InternalBundle extends AbstractBundle
         // SERVICES
         $container->import('../config/services.php');
 
-        // ENV DEFAULTS
-        $container->parameters()->set('env(APP_SECRET)', '');
-        $container->parameters()->set('env(HYVOR_INSTANCE)', 'https://hyvor.com');
-        $container->parameters()->set('env(HYVOR_PRIVATE_INSTANCE)', null);
-        $container->parameters()->set('env(HYVOR_FAKE)', '0');
-        $container->parameters()->set('env(AUTH_METHOD)', 'hyvor'); // hyvor or openid
+        $container->parameters()
+            ->set('internal.default_auth_method', 'oidc')
+            ->set('internal.default_instance', 'https://hyvor.com')
+            ->set('internal.default_private_instance', null)
+            ->set('internal.default_fake', false);
 
         // InternalConfig class
         $container->services()
@@ -74,62 +64,27 @@ class InternalBundle extends AbstractBundle
             ->args([
                 '%env(APP_SECRET)%',
                 $config['component'],
-                $config['auth_method'],
-                $config['instance'],
-                $config['private_instance'],
-                $config['fake'],
+                '%env(default:internal.default_auth_method:AUTH_METHOD)%',
+                '%env(default:internal.default_instance:HYVOR_INSTANCE)%',
+                '%env(default:internal.default_private_instance:HYVOR_PRIVATE_INSTANCE)%',
+                '%env(bool:default:internal.default_fake:HYVOR_FAKE)%',
                 $config['i18n']['folder'],
                 $config['i18n']['default'],
             ]);
 
-        // Main Services
-        $authMethod = $builder->resolveEnvPlaceholders('%env(AUTH_METHOD)%', true);
+        $container
+            ->services()
+            ->set(AuthInterface::class)
+            ->factory([service(AuthFactory::class), 'create']);
 
-        $container->services()->alias(
-            AuthInterface::class,
-            $authMethod === 'oidc' ? OidcAuth::class : Auth::class
-        );
-        $container->services()->alias(BillingInterface::class, Billing::class);
+        $container
+            ->services()
+            ->set(BillingInterface::class)
+            ->public() // because this is not used from outside, so tests fail (inlined)
+            ->factory([service(BillingFactory::class), 'create']);
+
+        // other services
         $container->services()->alias(SelfHostedTelemetryInterface::class, SelfHostedTelemetry::class);
-
-        $isFake = boolval($builder->resolveEnvPlaceholders('%env(HYVOR_FAKE)%', true));
-        if ($isFake && $container->env() === 'dev') {
-            $this->setupFake($container);
-        }
-    }
-
-    private function setupFake(ContainerConfigurator $container): void
-    {
-        $class = class_exists('App\InternalFake') ? 'App\InternalFake' : InternalFake::class;
-
-        /** @var class-string<InternalFake> $class */
-        $fakeConfig = new $class;
-        $user = $fakeConfig->user();
-        $usersDatabase = $fakeConfig->usersDatabase();
-
-        // AUTH FAKE
-        $container
-            ->services()
-            ->alias(AuthInterface::class, AuthFake::class);
-        $container->services()
-            ->get(AuthFake::class)
-            ->args([
-                $user?->toArray(),
-                $usersDatabase,
-            ]);
-
-        // BILLING FAKE
-        $container
-            ->services()
-            ->alias(BillingInterface::class, BillingFake::class);
-        $container
-            ->services()
-            ->set(BillingFakeLicenseProvider::class, BillingFakeLicenseProvider::class)
-            ->args([$class]);
-        $container->services()
-            ->get(BillingFake::class)
-            ->arg('$license', [service(BillingFakeLicenseProvider::class), 'license'])
-            ->arg('$licenses', [service(BillingFakeLicenseProvider::class), 'licenses']);
     }
 
 }

--- a/src/Auth/AuthFactory.php
+++ b/src/Auth/AuthFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Hyvor\Internal\Auth;
+
+use Hyvor\Internal\Auth\Oidc\OidcAuth;
+use Hyvor\Internal\InternalConfig;
+use Hyvor\Internal\InternalFake;
+
+class AuthFactory
+{
+
+    public function __construct(
+        private InternalConfig $internalConfig,
+        private Auth $hyvorAuth,
+        private OidcAuth $oidcAuth,
+    ) {
+    }
+
+    public function create(): AuthInterface
+    {
+        if ($this->internalConfig->getAuthMethod() === AuthMethod::HYVOR) {
+            if ($this->internalConfig->isFake()) {
+                $fake = InternalFake::getInstance();
+                return new AuthFake($fake->user(), $fake->usersDatabase());
+            }
+            return $this->hyvorAuth;
+        }
+
+        return $this->oidcAuth;
+    }
+
+}

--- a/src/Billing/BillingFactory.php
+++ b/src/Billing/BillingFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Hyvor\Internal\Billing;
+
+use Hyvor\Internal\Bundle\BillingFakeLicenseProvider;
+use Hyvor\Internal\InternalConfig;
+use Hyvor\Internal\InternalFake;
+
+class BillingFactory
+{
+
+    public function __construct(
+        private InternalConfig $internalConfig,
+        private Billing $billing,
+    ) {
+    }
+
+    public function create(): BillingInterface
+    {
+        if ($this->internalConfig->isFake()) {
+            $fake = InternalFake::getInstance();
+            $fakeLicenseProvider = new BillingFakeLicenseProvider(get_class($fake));
+            return new BillingFake(
+                $this->internalConfig,
+                [$fakeLicenseProvider, 'license'],
+                [$fakeLicenseProvider, 'licenses']
+            );
+        }
+        return $this->billing;
+    }
+
+}

--- a/src/InternalFake.php
+++ b/src/InternalFake.php
@@ -47,7 +47,7 @@ class InternalFake
 
     /**
      * Returns a collection of licenses for the given LicenseOf objects.
-     * @@codeCoverageIgnore TODO: add coverage later
+     * @codeCoverageIgnore TODO: add coverage later
      * @param LicenseOf[] $of
      */
     public function licenses(array $of, Component $component): LicensesCollection
@@ -62,6 +62,16 @@ class InternalFake
             ];
         }
         return new LicensesCollection($licenses, $component);
+    }
+
+    /**
+     * If App\InternalFake exists, it returns its instance. Otherwise, it returns an instance of this class.
+     */
+    public static function getInstance(): InternalFake
+    {
+        /** @var class-string<InternalFake> $class */
+        $class = class_exists('App\InternalFake') ? 'App\InternalFake' : InternalFake::class;
+        return new $class;
     }
 
 }

--- a/tests/Bundle/InternalBundleTest.php
+++ b/tests/Bundle/InternalBundleTest.php
@@ -39,13 +39,10 @@ class InternalBundleTest extends TestCase
         $this->assertInstanceOf(ArrayNodeDefinition::class, $rootNode);
         $childNodes = $rootNode->getChildNodeDefinitions();
         $this->assertArrayHasKey('component', $childNodes);
-        $this->assertArrayHasKey('instance', $childNodes);
-        $this->assertArrayHasKey('private_instance', $childNodes);
-        $this->assertArrayHasKey('fake', $childNodes);
         $this->assertArrayHasKey('i18n', $childNodes);
     }
 
-    private function getContainerBuilder(bool $dev = false): ContainerBuilder
+    public function test_extension(): void
     {
         $instanceof = [];
         $containerBuilder = new ContainerBuilder();
@@ -55,7 +52,7 @@ class InternalBundleTest extends TestCase
             $instanceof,
             'path',
             'file',
-            $dev ? 'dev' : null
+            null
         );
 
         $containerConfigurator->services()->set(InternalConfig::class, InternalConfig::class);
@@ -72,7 +69,7 @@ class InternalBundleTest extends TestCase
             'instance' => 'https://hyvor.com',
             'auth_method' => 'hyvor',
             'private_instance' => null,
-            'fake' => $dev,
+            'fake' => false,
             'i18n' => [
                 'folder' => '%kernel.project_dir%/../shared/locale',
                 'default' => 'en-US',
@@ -80,33 +77,7 @@ class InternalBundleTest extends TestCase
         ];
         $bundle->loadExtension($config, $containerConfigurator, $containerBuilder);
 
-        return $containerBuilder;
-    }
-
-    public function test_load_extension(): void
-    {
-        $containerBuilder = $this->getContainerBuilder();
-
-        // internal config
         $internalConfig = $containerBuilder->get(InternalConfig::class);
         $this->assertInstanceOf(InternalConfig::class, $internalConfig);
-        $this->assertSame(Component::CORE, $internalConfig->getComponent());
-        $this->assertSame('https://hyvor.com', $internalConfig->getInstance());
-        $this->assertSame(null, $internalConfig->getPrivateInstance());
-        $this->assertFalse($internalConfig->isFake());
-        $this->assertSame('/path/to/project/../shared/locale', $internalConfig->getI18nFolder());
-        $this->assertSame('en-US', $internalConfig->getI18nDefaultLocale());
-
-        // bindings
-        $this->assertSame(Auth::class, (string)$containerBuilder->getAlias(AuthInterface::class));
-        $this->assertSame(Billing::class, (string)$containerBuilder->getAlias(BillingInterface::class));
     }
-
-    public function test_load_extension_on_dev(): void
-    {
-        $_ENV['HYVOR_FAKE'] = '1';
-        $containerBuilder = $this->getContainerBuilder(true);
-        $this->assertSame(AuthFake::class, (string)$containerBuilder->getAlias(AuthInterface::class));
-    }
-
 }

--- a/tests/Unit/Auth/AuthFactoryTest.php
+++ b/tests/Unit/Auth/AuthFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Hyvor\Internal\Tests\Unit\Auth;
+
+use Hyvor\Internal\Auth\Auth;
+use Hyvor\Internal\Auth\AuthFactory;
+use Hyvor\Internal\Auth\AuthFake;
+use Hyvor\Internal\Auth\Oidc\OidcAuth;
+use Hyvor\Internal\Tests\SymfonyTestCase;
+
+class AuthFactoryTest extends SymfonyTestCase
+{
+
+    public function test_create_hyvor_fake(): void
+    {
+        $_ENV['HYVOR_FAKE'] = '1';
+        $_ENV['AUTH_METHOD'] = 'hyvor';
+
+        /** @var AuthFactory $factory */
+        $factory = $this->container->get(AuthFactory::class);
+        $auth = $factory->create();
+
+        $this->assertInstanceOf(AuthFake::class, $auth);
+
+        unset($_ENV['HYVOR_FAKE']);
+        unset($_ENV['AUTH_METHOD']);
+    }
+
+    public function test_create_hyvor(): void
+    {
+        $_ENV['AUTH_METHOD'] = 'hyvor';
+
+        /** @var AuthFactory $factory */
+        $factory = $this->container->get(AuthFactory::class);
+        $auth = $factory->create();
+
+        $this->assertInstanceOf(Auth::class, $auth);
+
+        unset($_ENV['AUTH_METHOD']);
+    }
+
+    public function test_create_oidc(): void
+    {
+        $_ENV['AUTH_METHOD'] = 'oidc';
+
+        /** @var AuthFactory $factory */
+        $factory = $this->container->get(AuthFactory::class);
+        $auth = $factory->create();
+
+        $this->assertInstanceOf(OidcAuth::class, $auth);
+
+        unset($_ENV['AUTH_METHOD']);
+    }
+
+}

--- a/tests/Unit/Billing/BillingFactoryTest.php
+++ b/tests/Unit/Billing/BillingFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Hyvor\Internal\Tests\Unit\Billing;
+
+use Hyvor\Internal\Billing\Billing;
+use Hyvor\Internal\Billing\BillingFactory;
+use Hyvor\Internal\Billing\BillingFake;
+use Hyvor\Internal\Tests\SymfonyTestCase;
+
+class BillingFactoryTest extends SymfonyTestCase
+{
+
+    public function test_fake(): void
+    {
+        $_ENV['HYVOR_FAKE'] = '1';
+
+        $billingFactory = $this->container->get(BillingFactory::class);
+        $this->assertInstanceOf(BillingFactory::class, $billingFactory);
+
+        $billing = $billingFactory->create();
+        $this->assertInstanceOf(BillingFake::class, $billing);
+
+        unset($_ENV['HYVOR_FAKE']);
+    }
+
+    public function test_real(): void
+    {
+        $billingFactory = $this->container->get(BillingFactory::class);
+        $this->assertInstanceOf(BillingFactory::class, $billingFactory);
+
+        $billing = $billingFactory->create();
+        $this->assertInstanceOf(Billing::class, $billing);
+    }
+
+}


### PR DESCRIPTION
- No longer uses compile-time env resolving
- env() params no longer used in the container
- internal.default_ params added